### PR TITLE
Improvements round

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 /gems
 /Gemfile.lock
 /debug*
+slacktail_debug.yml
 *.gem

--- a/Runfile
+++ b/Runfile
@@ -17,44 +17,21 @@ action :console, :c do
 end
 
 help   "Test message rendering"
-action :render do
+usage  "render [YAMLFILE]"
+action :render do |args|
+  file = args['YAMLFILE']
+
   Client.default.start_async # in order to have channels and users list
-  Message.new(message_mock).render
+
+  message = file ? YAML.load_file("#{file}.yml") : message_mock
+  message = Message.new message
+  message.render
 end
 
-help   "Simulated run for recording the demo"
-action :simulate do |args|
-  client = Mocks::Client.new echo: false
-  Client.default = client
-  Command.new.run
-  
-  sleep 2
-  mock = Mocks::Message.new(attachments: false, message: "I’ll never turn to the dark side. You’ve failed, your highness. I am a Jedi, like my father before me.")
-  client.simulate :message, mock
-  
-  sleep 2
-  mock = Mocks::Message.new(message2: '', user: :bot, color: 'ffff00', message: "*Build started* some.production.service.com")
-  client.simulate :message, mock
-  
-  sleep 4
-  mock = Mocks::Message.new(message2: '', user: :bot, color: 'ff0000', message: "**Build FAILED**:\n\nBuild number `45` failed in `production`")
-  client.simulate :message, mock
+require_relative 'demo'
+require_relative 'debug' if File.exist? 'debug.rb'
 
-  sleep 6
-  mock = Mocks::Message.new(attachments: false, message: "Fixed, deploying again")
-  client.simulate :message, mock
-  
-  sleep 3
-  mock = Mocks::Message.new(message2: '', user: :bot, color: 'ffff00', message: "*Build started* some.production.service.com")
-  client.simulate :message, mock
-  
-  sleep 4
-  mock = Mocks::Message.new(message2: '', user: :bot, color: '00ff00', message: "**Build SUCCEEDED**:\n\nBuild number `45` deployed to `production`")
-  client.simulate :message, mock
-
-  sleep 10
-end
-
+# Mock for quick and dirty use with run render
 def message_mock
   OpenStruct.new({
     text: "Hello tester",
@@ -72,4 +49,3 @@ def message_mock
   })
 end
 
-require_relative 'debug' if File.exist? 'debug.rb'

--- a/demo.rb
+++ b/demo.rb
@@ -1,0 +1,32 @@
+help   "Simulated run for recording the demo"
+action :demo do |args|
+  client = Mocks::Client.new echo: false
+  Client.default = client
+  Command.new.run
+  
+  sleep 2
+  mock = Mocks::Message.new(attachments: false, message: "I’ll never turn to the dark side. You’ve failed, your highness. I am a Jedi, like my father before me.")
+  client.simulate :message, mock
+  
+  sleep 2
+  mock = Mocks::Message.new(message2: '', user: :bot, color: 'ffff00', message: "*Build started* some.production.service.com")
+  client.simulate :message, mock
+  
+  sleep 4
+  mock = Mocks::Message.new(message2: '', user: :bot, color: 'ff0000', message: "**Build FAILED**:\n\nBuild number `45` failed in `production`")
+  client.simulate :message, mock
+
+  sleep 6
+  mock = Mocks::Message.new(attachments: false, message: "Fixed, deploying again")
+  client.simulate :message, mock
+  
+  sleep 3
+  mock = Mocks::Message.new(message2: '', user: :bot, color: 'ffff00', message: "*Build started* some.production.service.com")
+  client.simulate :message, mock
+  
+  sleep 4
+  mock = Mocks::Message.new(message2: '', user: :bot, color: '00ff00', message: "**Build SUCCEEDED**:\n\nBuild number `45` deployed to `production`")
+  client.simulate :message, mock
+
+  sleep 10
+end

--- a/lib/slacktail.rb
+++ b/lib/slacktail.rb
@@ -1,7 +1,6 @@
 require 'requires'
 require 'mister_bin'
 require 'slack-ruby-client'
-require 'tty-markdown'
 require 'byebug' if ENV['BYEBUG']
 
 requires \

--- a/lib/slacktail/command.rb
+++ b/lib/slacktail/command.rb
@@ -24,7 +24,7 @@ module Slacktail
 
     def start_client
       client.on :message do |data|
-        # File.write 'debug.yml', data.to_yaml
+        File.write('slacktail_debug.yml', data.to_yaml) if ENV['SLACKTAIL_DEBUG']
         @message = Message.new data
         @message.render unless skip?
       end

--- a/lib/slacktail/extensions/string.rb
+++ b/lib/slacktail/extensions/string.rb
@@ -1,8 +1,4 @@
 class String
-  def to_markdown
-    TTY::Markdown.parse self
-  end
-
   def to_colsole_color
     color = {
       '000000' => :blk,

--- a/lib/slacktail/message_view.rb
+++ b/lib/slacktail/message_view.rb
@@ -9,7 +9,7 @@ module Slacktail
 
       items.each do |line|
         if line.is_a? String
-          say "#{prefix}#{line.to_markdown}".strip
+          say "#{prefix}#{line}".strip
         elsif line.is_a? Field
           say "#{prefix}!txtblu!#{line.key}!txtrst! : !txtgrn!#{line.value}".strip
         end

--- a/slacktail.gemspec
+++ b/slacktail.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'async-websocket', '~> 0.6'
   s.add_runtime_dependency 'mister_bin', '~> 0.5'
+  s.add_runtime_dependency 'colsole', '~> 0.5', '>= 0.5.3'
   s.add_runtime_dependency 'requires', '~> 0.1'
   s.add_runtime_dependency 'slack-ruby-client', '~> 0.13'
-  s.add_runtime_dependency 'tty-markdown', '~> 0.4'
 end

--- a/spec/fixtures/command/message
+++ b/spec/fixtures/command/message
@@ -1,6 +1,6 @@
-[0m▌[0m [0;36m17:01 : [1;36m@Luke[0;36m : #debug
+[0m▌[0m [0;36m11:39 : [1;36m@Luke[0;36m : #debug
 [0m[0m▌[0m Main message text
-[0m▌[0m [33mBuild SUCCESS[0m: [33mdeploy-website[0m [33m#45[0m
+[0m▌[0m *Build SUCCESS*: `deploy-website` *#45*
 [0m▌[0m [0;34mBuild Number[0m : [0;32m45
 [0m[0m▌[0m [0;34mEnvironment[0m : [0;32mProduction
 [0m


### PR DESCRIPTION
- [x] Extract demo generator from Runfile demo.rb
- [x] Remove markdown parser, causes too many weird issues - will now display the incoming text as is
- [x] Increase colsole dependency requirement to 0.5.3, since it now has a better `word_wrap` function
- [x] Setting the `SLACKTAIL_DEBUG` environment variable will cause slacktail to save the last received message in a YAML file in the current directory, for debugging.
- [x] Added `run render YAMLFILE` to quickly view a serialized message from YAML.