### PR TITLE
Upgrade slack ruby client to 0.15.1

### DIFF
--- a/.changelog.old.md
+++ b/.changelog.old.md
@@ -1,12 +1,3 @@
-Change Log
-========================================
-
-Untagged - Latest
-----------------------------------------
-
-- Upgrade slack ruby client to 0.15.1
-
-
 ## [v0.1.1](https://github.com/DannyBen/slacktail/tree/v0.1.1) (2019-01-02)
 [Full Changelog](https://github.com/DannyBen/slacktail/compare/v0.1.0...v0.1.1)
 

--- a/Runfile
+++ b/Runfile
@@ -28,6 +28,13 @@ action :render do |args|
   message.render
 end
 
+help   "Generate changelog and append old changelog"
+action :changelog do
+  run "git changelog --save"
+  # append older changelog (prior to switching to git-changelog)
+  run "cat .changelog.old.md >> CHANGELOG.md"
+end
+
 require_relative 'demo'
 require_relative 'debug' if File.exist? 'debug.rb'
 

--- a/slacktail.gemspec
+++ b/slacktail.gemspec
@@ -20,10 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'mister_bin', '~> 0.6'
   s.add_runtime_dependency 'colsole', '~> 0.5', '>= 0.5.3'
   s.add_runtime_dependency 'requires', '~> 0.1'
-  
-  # Reason for locking to 0.14.1:
-  # ref: https://github.com/slack-ruby/slack-ruby-client/issues/272
-  s.add_runtime_dependency 'slack-ruby-client', '~> 0.13', '<= 0.14.1'
+  s.add_runtime_dependency 'slack-ruby-client', '~> 0.15', '>= 0.15.1'
 
   # Other versions are incompatible
   s.add_runtime_dependency 'async-websocket', '~> 0.8.0'


### PR DESCRIPTION
Despite https://github.com/slack-ruby/slack-ruby-client/issues/272 still being open, the error seems to have gone away with version 0.15.1 of the slack-ruby-client.

This upgrade was necessary since older version started to generate this error all of a sudden:

```
#<Thread:0x00005590218ccad8 /store/gems/ruby-2.7.0/gems/slack-ruby
-client-0.14.1/lib/slack/real_time/concurrency/async.rb:22 run> terminated with
exception (report_on_exception is true):
Traceback (most recent call last):
/store/gems/ruby-2.7.0/gems/slack-ruby-client-0.14.1/lib/slack/real_time/concurr
ency/async.rb:24:in `block in start_async': undefined method `every' for #<Slack
::RealTime::Concurrency::Async::Reactor:0x00005590218ce4f0> (NoMethodError)
NoMethodError: undefined method `every' for #<Slack::RealTime::Concurrency::Asyn
c::Reactor:0x00005590218ce4f0>
```